### PR TITLE
antman: readme: make script executable after downloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Here's an exmaple on how to sync latest build using AntMan:
 mkdir -p "$HOME/toolchains/neutron-clang"
 cd "$HOME/toolchains/neutron-clang"
 curl -LO "https://raw.githubusercontent.com/Neutron-Toolchains/antman/main/antman"
+chmod +x antman
 ./antman -S
 ```
 


### PR DESCRIPTION
- Currently, copy-pasting commands results in an error, we don't want that

❯ mkdir -p "$HOME/toolchains/neutron-clang"
cd "$HOME/toolchains/neutron-clang"
curl -LO "https://raw.githubusercontent.com/Neutron-Toolchains/antman/main/antman"
./antman -S
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 16120  100 16120    0     0  35286      0 --:--:-- --:--:-- --:--:-- 35273
zsh: permission denied: ./antman