### PR TITLE
antman: Add a wget version check

### DIFF
--- a/antman
+++ b/antman
@@ -371,7 +371,15 @@ if [[ $* =~ "--noconfirm" ]]; then
     NOCONFIRM=1
 fi
 
-WGET_ARGS=("--quiet" "--show-progress")
+# Extract wget version. Outputs either major version 1, or 2
+WGET_VER=$(wget --version | head -n 1 | cut -d ' ' -f 3 | cut -d '.' -f 1)
+
+if [[ "$WGET_VER" -ge 2 ]]; then
+    WGET_ARGS=("--quiet" "--force-progress")
+else
+    WGET_ARGS=("--quiet" "--show-progress")
+fi
+
 if [[ $* =~ "--noprogress" ]]; then
     WGET_ARGS=("--quiet")
 fi


### PR DESCRIPTION
Under a Fedora 40 installation, `wget2` is symlinked as `wget`

And the `--show-progress` option does not exist within `wget2` (as it was replaced by the `--force-progress` flag),
and so, it throws this error if used as a command argument:

```shell
$  Unknown option 'show-progress'
```

This stops the antman script when trying to fetch the build tar ([antman-log.txt](https://github.com/user-attachments/files/16756567/antman-log.txt)).


- So in order to support older and newer `wget` versions at once, a solution to this is by adding a check to if the machine is running a `wget` major version 1, or 2 and using the appropriate command argument